### PR TITLE
Use iterative parse method instead of recursive parse

### DIFF
--- a/src/ngx_http_rds_json_filter_module.c
+++ b/src/ngx_http_rds_json_filter_module.c
@@ -239,6 +239,7 @@ ngx_http_rds_json_header_filter(ngx_http_request_t *r)
     ctx->tag = (ngx_buf_tag_t) &ngx_http_rds_json_filter_module;
 
     ctx->state = state_expect_header;
+    ctx->handler = ngx_http_rds_json_process_header;
 
     ctx->header_sent = 0;
 
@@ -295,6 +296,22 @@ ngx_http_rds_json_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
             "rds json body filter postponed header sending");
 
+        if (ctx->handler) {
+            rc = ctx->handler(r, in, ctx);
+        } else {
+            /* status done */
+
+            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                    "rds json body filter discarding unexpected trailing buffers");
+
+            /* mark the remaining bufs as consumed */
+
+            ngx_http_rds_json_discard_bufs(r->pool, in);
+
+            return NGX_OK;
+        }
+
+#if 0
     switch (ctx->state) {
     case state_expect_header:
         rc = ngx_http_rds_json_process_header(r, in, ctx);
@@ -336,7 +353,7 @@ ngx_http_rds_json_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
         break;
     }
-
+#endif
     dd("body filter rc: %d", (int) rc);
 
     if (rc == NGX_ERROR || rc >= NGX_HTTP_SPECIAL_RESPONSE) {

--- a/src/ngx_http_rds_json_filter_module.h
+++ b/src/ngx_http_rds_json_filter_module.h
@@ -78,7 +78,12 @@ typedef enum {
 } ngx_http_rds_json_state_t;
 
 
-typedef struct {
+typedef struct ngx_http_rds_json_ctx_s  ngx_http_rds_json_ctx_t;
+
+typedef ngx_int_t (*rds_json_process_handler_pt)(ngx_http_request_t *r,
+        ngx_chain_t *in, ngx_http_rds_json_ctx_t *ctx);
+
+struct ngx_http_rds_json_ctx_s {
     ngx_http_rds_json_state_t            state;
 
     ngx_str_t                           *col_name;
@@ -106,10 +111,13 @@ typedef struct {
 
     uint32_t                             field_data_rest;
 
+    rds_json_process_handler_pt          handler;
+
     ngx_flag_t                           header_sent:1;
     ngx_flag_t                           seen_stream_end:1;
     ngx_flag_t                           generated_col_names:1;
-} ngx_http_rds_json_ctx_t;
+};
+
 
 
 #endif /* NGX_HTTP_RDS_JSON_FILTER_MODULE_H */


### PR DESCRIPTION
The original recursive parse would cause stack size exceeding system limit and a segment fault when dealing with large date ( usually 100k lines or more ).
